### PR TITLE
create workflow for development and CICD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: "CI"
+on: ["push", "pull_request"]
+
+jobs:
+  ci:
+    name: "Run CI"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - uses: WillAbides/setup-go-faster@v1.14.0
+      with:
+        go-version: 1.22.x
+    - run: "go test ./..."
+    - run: "go vet ./..."
+    - uses: dominikh/staticcheck-action@v1.3.1
+      with:
+        version: "latest"
+        install-go: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,23 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
-      - uses: DeterminateSystems/flake-checker-action@main
-      - name: "Run static analysis and unit tests"
-        run: nix flake check
       - name: "Build Docker image"
         run: nix build .#docker
       - name: "Build native binary"
         run: nix build .#bin
+      - name: "Static check"
+        run: >-
+          nix develop --command staticcheck ./...
+      - name: "Revive"
+        run: >-
+          nix develop --command revive ./...
+      - name: "Go vet"
+        run: >-
+          nix develop --command go vet ./...
+      - name: "Go test"
+        run: >-
+          nix develop --command go test
+          -race
+          -coverprofile=coverage.txt
+          -covermode atomic
+          ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,7 @@ jobs:
           -coverprofile=coverage.txt
           -covermode atomic
           ./...
+      - name: "Upload coverage report"
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
           -covermode atomic
           ./...
       - name: "Upload coverage report"
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          fail_ci_if_error: true
           files: ./coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,19 +2,19 @@ name: "CI"
 on: ["push", "pull_request"]
 
 jobs:
-  ci:
-    name: "Run CI"
-    runs-on: ubuntu-latest
+  tests:
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: "write"
+      contents: "read"
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-    - uses: WillAbides/setup-go-faster@v1.14.0
-      with:
-        go-version: 1.22.x
-    - run: "go test ./..."
-    - run: "go vet ./..."
-    - uses: dominikh/staticcheck-action@v1.3.1
-      with:
-        version: "latest"
-        install-go: false
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/flake-checker-action@main
+      - name: "Run static analysis and unit tests"
+        run: nix flake check
+      - name: "Build Docker image"
+        run: nix build .#docker
+      - name: "Build native binary"
+        run: nix build .#bin

--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,23 @@
-# If you prefer the allow list template instead of the deny list, see community template:
-# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+# Allowlisting gitignore template for GO projects prevents us
+# from adding various unwanted local files, such as generated
+# files, developer configurations or IDE-specific files etc.
 #
-# Binaries for programs and plugins
-*.exe
-*.exe~
-*.dll
-*.so
-*.dylib
+# Recommended: Go.AllowList.gitignore
 
-# Test binary, built with `go test -c`
-*.test
+# Ignore everything
+*
 
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
+# But not these files...
+!/.gitignore
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+!*.go
+!go.sum
+!go.mod
 
-# Go workspace file
-go.work
-go.work.sum
+!README.md
+!LICENSE
+
+# !Makefile
+
+# ...even if they are in subdirectories
+!*/

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 !README.md
 !LICENSE
 
+!flake.nix
+!flake.lock
+
 # !Makefile
 
 # ...even if they are in subdirectories

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,5 @@
 
 !.github/workflows/*.yml
 
-# !Makefile
-
 # ...even if they are in subdirectories
 !*/

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@
 !flake.nix
 !flake.lock
 
+!.github/workflows/*.yml
+
 # !Makefile
 
 # ...even if they are in subdirectories

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # jira-clone
+[![codecov](https://codecov.io/github/ARLJohnston/jira-clone/graph/badge.svg?token=G9YO8HYCDG)](https://codecov.io/github/ARLJohnston/jira-clone)
 Jira clone using Go, gRPC, immutability and HTMX
 
 The prerequisites to running the project are stored in the [./flake.nix]flake devShell buildInputs

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # jira-clone
 Jira clone using Go, gRPC, immutability and HTMX
+
+## Workflow
+Nix is used to manage dependencies, run tests and build the project
+
+To enter into a shell with all project dependencies:
+```bash
+nix develop
+```
+This installs Go development tools (go, gopls, staticcheck)
+
+To build and run the project as a binary use:
+```bash
+nix build .#bin
+./result/bin/jira
+```
+
+To build and run the project as a Docker image use:
+```bash
+nix build .#docker
+docker load < ./result
+docker run jira-clone
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # jira-clone
 Jira clone using Go, gRPC, immutability and HTMX
 
+The prerequisites to running the project are stored in the [./flake.nix]flake devShell buildInputs
+
 ## Workflow
 Nix is used to manage dependencies, run tests and build the project
 

--- a/cmd/jira/main.go
+++ b/cmd/jira/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("test")
+}

--- a/cmd/jira/main.go
+++ b/cmd/jira/main.go
@@ -1,3 +1,4 @@
+// Package implements the main jira functionality of the backend
 package main
 
 import (

--- a/cmd/jira/main_test.go
+++ b/cmd/jira/main_test.go
@@ -1,0 +1,17 @@
+// Testing for main
+package main
+
+import (
+	"testing"
+)
+
+func TestMain(t *testing.T) {
+	t.Run("Placeholder Test", func(t *testing.T) {
+		got := "Placeholder"
+		want := "Placeholder"
+
+		if got != want {
+			t.Errorf("got %q want %q", got, want)
+		}
+	})
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1720542800,
+        "narHash": "sha256-ZgnNHuKV6h2+fQ5LuqnUaqZey1Lqqt5dTUAiAnqH0QQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "feb2849fdeb70028c70d73b848214b00d324a497",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,42 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1720542800,
@@ -15,9 +52,63 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1720386169,
+        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1719082008,
+        "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9693852a2070b398ee123a329e68f0dab5526681",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1720524665,
+        "narHash": "sha256-ni/87oHPZm6Gv0ECYxr1f6uxB0UKBWJ6HvS7lwLU6oY=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "8d6a17d0cdf411c55f12602624df6368ad86fac1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,8 @@
           docker = pkgs.dockerTools.buildLayeredImage {
             name = "jira-clone";
             tag = "latest";
-            config.Cmd = "${bin}/bin/jira";
+            created = "now";
+            config.Cmd = [ "${bin}/bin/jira" ];
           };
         });
 

--- a/flake.nix
+++ b/flake.nix
@@ -23,11 +23,12 @@
         in {
           default = pkgs.mkShell {
             buildInputs = with pkgs; [
-              go_1_22
-              gotools
               go-tools
+              go_1_22
               gopls
+              gotools
               nixpkgs-fmt
+              revive
             ];
           };
         });
@@ -37,6 +38,7 @@
           src = ./.;
           hooks = {
             gofmt.enable = true;
+            gotest.enable = true;
             govet.enable = true;
             revive.enable = true;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "Jira-clone flake";
+
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      version = builtins.substring 0 1 self.lastModifiedDate;
+
+      supportedSystems =
+        [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      nixpkgsFor = forAllSystems (system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ (final: prev: { go = prev.go_1_22; }) ];
+        });
+    in {
+      devShell = forAllSystems (system:
+        let pkgs = nixpkgsFor.${system};
+        in with pkgs;
+        mkShell {
+          buildInputs = [ go_1_21 gotools go-tools gopls nixpkgs-fmt ];
+        });
+
+      packages = forAllSystems (system:
+        let pkgs = nixpkgsFor.${system};
+        in rec {
+          bin = pkgs.buildGoModule {
+            pname = "jira-clone";
+            inherit version;
+            src = ./.;
+            vendorHash = null;
+          };
+
+          docker = pkgs.dockerTools.buildLayeredImage {
+            name = "jira-clone";
+            tag = "latest";
+            config.Cmd = "${bin}/bin/jira";
+          };
+        });
+
+    };
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ARLJohnston/jira-clone
+
+go 1.22.3


### PR DESCRIPTION
Closes #1 

Creates (and documents):
  - Nix flake for devshell: Ensures all developers have same software versions (i.e. no 'it works on my machine') 
    - `nix develop` enters into the devshell and install dependencies
  - Build process for native binary and Docker image
    - `nix build .#{bin||docker}`
  - CICD pipeline
    - Installs Nix and runs go vet, revive and unit tests
    - Uses caching for fast reruns (~1min 30s per run)